### PR TITLE
Git: Add alias for get log on merge-base to HEAD

### DIFF
--- a/files/gitconfig
+++ b/files/gitconfig
@@ -17,5 +17,9 @@
 	br = branch
 	sdiff = diff --staged
 	tree = log --graph --full-history --all --color --date=short --pretty=format:\"%Cred%x09%h %Creset%ad%Cblue%d %Creset %s %C(bold)(%an)%Creset\"
+    log-base-forward = "!f() { \
+        base=`git merge-base $1 HEAD`; \
+        git log $base..$1 $@; \
+    }; f"
 	type = cat-file -t
 	dump = cat-file -p


### PR DESCRIPTION
Given two commits A and B, git merge-base A B will output a commit
which is reachable from both A and B through the parent relationship.

For example, with this topology:

```
         o---o---o---B
        /
---o---1---o---o---o---A
```

the merge base between A and B is 1.

`git log-base-forward A` in this case equal `git log 1..A`
`git log-base-forward B` in this case equal `git log 1..B`
